### PR TITLE
Fix tcp requset forward dns failed

### DIFF
--- a/core/query.c
+++ b/core/query.c
@@ -315,8 +315,10 @@ query_response(struct kdns * kdns, struct query *q)
 
 	answer_lookup_zone( kdns, q, &answer, exact, closest_match,closest_encloser);
 
-    encode_answer(q, &answer);
-    query_compressed_table_clear(q);
+    if (GET_RCODE(q->packet) != RCODE_REFUSE) {
+        encode_answer(q, &answer);
+        query_compressed_table_clear(q);
+    }
 }
 
 void


### PR DESCRIPTION
When requset forward dns through tcp, the forward packet's Additional
RRs section is worng, So forward dns server may rst the connection.