### PR TITLE
fix when round_robin_off overflow, cause coredump

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -103,7 +103,7 @@ packet_encode_rrset(kdns_query_st *query, domain_type *owner,
 {
 	uint16_t i;
 	uint16_t added = 0;  
-	static int round_robin_off = 0;
+	static uint16_t round_robin_off = 0;
 	int do_robin = (round_robin && section == ANSWER_SECTION);
 	uint16_t start;
     uint32_t maxAnswer = 65535;


### PR DESCRIPTION
(gdb) bt full
#0  0x000000000045752c in rdata_atom_wireformat_type (type=32641, index=0) at /home/yeze/yz-containerdns-c/core/domain_store.h:259
        descriptor = 0x0
        __PRETTY_FUNCTION__ = "rdata_atom_wireformat_type"
#1  0x000000000045776d in packet_encode_rr (q=0x1bad6a0, owner=0x7f814800e9e0, rr=0x7f814800f3e0, ttl=1208022800) at /home/yeze/yz-containerdns-c/core/packet.c:67
        truncation_mark = 120
        rdlength = 0
        rdlength_pos = 130
        j = 0
#2  0x0000000000457aaa in packet_encode_rrset (query=0x1bad6a0, owner=0x7f814800e9e0, rrset=0x7f814800ead0, section=1)
    at /home/yeze/yz-containerdns-c/core/packet.c:136
        i = 4
        added = 4
        round_robin_off = 54766
        do_robin = 1
        start = 65533
        maxAnswer = 65535
        truncate_rrset = 1
        all_added = 1
        __PRETTY_FUNCTION__ = "packet_encode_rrset"
        truncation_mark = 37
#3  0x0000000000451e6c in encode_answer (q=0x1bad6a0, answer=0x7f817b9f7900) at /home/yeze/yz-containerdns-c/core/query.c:428
        counts = {0, 0, 0, 0, 0}
        section = ANSWER_SECTION
        i = 0
#4  0x00000000004519e2 in query_response (kdns=0xf31ce8 <dpdk_dns+72>, q=0x1bad6a0) at /home/yeze/yz-containerdns-c/core/query.c:319
        closest_match = 0x7f814800e9e0
        closest_encloser = 0x7f814800e9e0
        answer = {rrset_count = 1, rrsets = {0x7f814800ead0, 0x0 <repeats 1023 times>}, domains = {0x7f814800e9e0, 0x0 <repeats 1023 times>}, section = {
            ANSWER_SECTION, QUESTION_SECTION <repeats 1023 times>}}
        exact = 1
#5  0x0000000000451c5e in query_process (q=0x1bad6a0, kdns=0xf31ce8 <dpdk_dns+72>) at /home/yeze/yz-containerdns-c/core/query.c:376
No locals.
#6  0x000000000044b292 in dns_packet_proess (pkt=0x7f7bced982c0, offset=42, received=37) at /home/yeze/yz-containerdns-c/src/kdns-adap.c:137
        lcore_id = 9
        rdata = 0x7f7bced983ea <Address 0x7f7bced983ea out of bounds>
        query = 0x1bad6a0
#7  0x000000000044d483 in packet_l3_handle (pkt=0x7f7bced982c0, conf=0x8d5500 <kdns_net_device+6976>) at /home/yeze/yz-containerdns-c/src/process.c:109
        received = 37
        flags_old = 1
        bufdata = 0x7f7bced983ea <Address 0x7f7bced983ea out of bounds>
        retLen = 32641
        eth_hdr_in = 0x7f7bced983c0
        ip_hdr_in = 0x7f7bced983ce
        udp_hdr_in = 0x7f7bced983e2
        tmp_eth_hdr = {d_addr = {addr_bytes = "\264\226\221\b\001"}, s_addr = {addr_bytes = "\000\000\220蔁{"}, ether_type = 32641}
---Type <return> to continue, or q <return> to quit--- 
        tmp_ipv4_hdr = {version_ihl = 0 '\000', type_of_service = 0 '\000', total_length = 0, packet_id = 65532, fragment_offset = 0, time_to_live = 252 '\374', 
          next_proto_id = 255 '\377', hdr_checksum = 0, src_addr = 0, dst_addr = 403736704}
        tmp_udp_hdr = {src_port = 0, dst_port = 0, dgram_len = 359, dgram_cksum = 0}
        ether_hdr_offset = 14
        ip_hdr_offset = 34
        udp_hdr_offset = 42
        query = 0x7f7bca9bbf00
        ip_headlen = 20
        ip_total_length = 65
#8  0x00000000004408c8 in packet_l2_handle (pkt=0x7f7bced982c0, conf=0x8d5500 <kdns_net_device+6976>) at /home/yeze/yz-containerdns-c/src/netdev.c:457
        eth_hdr = 0x7f7bced983c0
#9  0x000000000044dce5 in process_slave (arg=0x0) at /home/yeze/yz-containerdns-c/src/process.c:281
        mbufs = {0x7f7bced982c0, 0x7f7bced98c00, 0x7f7bced99540, 0x7f7bced99e80, 0x0 <repeats 28 times>}
        rx_count = 1
        lcore_id = 9
        t = 1
        k = 0
        conf = 0x8d5500 <kdns_net_device+6976>
#10 0x00000000004a04c5 in eal_thread_loop ()
No symbol table info available.
#11 0x00007f81d9501e25 in start_thread () from /lib64/libpthread.so.0
No symbol table info available.
#12 0x00007f81d8ae834d in clone () from /lib64/libc.so.6
No symbol table info available.